### PR TITLE
Updated temp path for log files during install...causing installation failure.

### DIFF
--- a/iis-arr/tools/chocolateyinstall.ps1
+++ b/iis-arr/tools/chocolateyinstall.ps1
@@ -14,7 +14,7 @@ $packageArgs = @{
   url           = $url
   url64bit      = $url64
 
-  silentArgs    = "/qn /norestart /l*v `"$env:TEMP\chocolatey\$($packageName)\$($packageName).MsiInstall.log`""
+  silentArgs    = "/qn /norestart /l*v `"$env:TEMP\$($packageName)\$($packageName).MsiInstall.log`""
   validExitCodes= @(0, 3010, 1641)
 
   softwareName  = 'Microsoft Application Request Routing 3.0'

--- a/iis-externalcache/tools/chocolateyinstall.ps1
+++ b/iis-externalcache/tools/chocolateyinstall.ps1
@@ -14,7 +14,7 @@ $packageArgs = @{
   url           = $url
   url64bit      = $url64
 
-  silentArgs    = "/qn /norestart /l*v `"$env:TEMP\chocolatey\$($packageName)\$($packageName).MsiInstall.log`""
+  silentArgs    = "/qn /norestart /l*v `"$env:TEMP\$($packageName)\$($packageName).MsiInstall.log`""
   validExitCodes= @(0, 3010, 1641)
 
   softwareName  = 'Microsoft External Cache'

--- a/iis-media-services/tools/chocolateyinstall.ps1
+++ b/iis-media-services/tools/chocolateyinstall.ps1
@@ -14,7 +14,7 @@ $packageArgs = @{
   url           = $url
   url64bit      = $url64
 
-  silentArgs    = "/qn /norestart /l*v `"$env:TEMP\chocolatey\$($packageName)\$($packageName).MsiInstall.log`""
+  silentArgs    = "/qn /norestart /l*v `"$env:TEMP\$($packageName)\$($packageName).MsiInstall.log`""
   validExitCodes= @(0, 3010, 1641)
 
   softwareName  = 'IIS Media Services 4.1'

--- a/urlrewrite/tools/chocolateyinstall.ps1
+++ b/urlrewrite/tools/chocolateyinstall.ps1
@@ -14,7 +14,7 @@ $packageArgs = @{
   url           = $url
   url64bit      = $url64
 
-  silentArgs    = "/qn /norestart /l*v `"$env:TEMP\chocolatey\$($packageName)\$($packageName).MsiInstall.log`""
+  silentArgs    = "/qn /norestart /l*v `"$env:TEMP\$($packageName)\$($packageName).MsiInstall.log`""
   validExitCodes= @(0, 3010, 1641)
 
   softwareName  = 'IIS URL Rewrite Module 2'


### PR DESCRIPTION
Per something I posted to the site, with choco 0.9.10-beta1, my attempted installs of any of these packages was failing.  It was looking for log files in %Temp%/chocolatey/chocolatey/  I just removed the "double chocolatey" by changing the path in the PS1 and this fixed my issue.
Perhaps default choco temp environment path changed but no longer need to manually add 'chocolatey' to it.  But not sure if this change will make it incompatible with earlier choco versions...in any case thought i'd submit a pull since it fixed my issue.
